### PR TITLE
Specify the key to use for signing.

### DIFF
--- a/scripts/create_attestation.sh
+++ b/scripts/create_attestation.sh
@@ -69,7 +69,7 @@ mkdir -p ~/.gnupg
 echo allow-loopback-pinentry > ~/.gnupg/gpg-agent.conf
 COMMON_FLAGS="--no-tty --pinentry-mode loopback  --passphrase-file ${NAME}.pass"
 gpg2 $COMMON_FLAGS --import ${NAME}_sec.gpg
-gpg2 $COMMON_FLAGS --output generated_signature.pgp --armor --sign generated_payload.json
+gpg2 $COMMON_FLAGS --output generated_signature.pgp --local-user $(cat ${NAME}.fpr) --armor --sign generated_payload.json
 
 # Upload attestation
 gcloud beta container binauthz attestations create \


### PR DESCRIPTION
Use the fingerprint to select the key from the gpg key ring that should be used for signing.  If this doesn't happen the first key will be used, which might not match the desired attestor.